### PR TITLE
Nu trebuie instalat create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Posibil să se schimbe în viitorul apropiat
 
 ## Instalare
 ```
-npm install -g create-react-app
 git clone https://github.com/gov-ithub/socent-frontend.git
 cd socent-frontend
 npm install


### PR DESCRIPTION
#### Fixes issue #N/A

#### Here are the changes I propose:
Nu trebuie instalat `create-react-app` pentru instalarea socent-frontend. `create-react-app` isi include scripturile de care are nevoie ca sa ruleze in package.json, iar restul functionalitatii (acela de a crea boilerplate pentru aplicatii noi) nu este necesar. Tot ce e necesar se afla in node_modules dupa `npm install`. PR-ul scoate pasul de instalare `create-react-app` din README.me 
#### Test plan:
- Sit back and observe 

#### Suggested reviewers: @gov-ithub/socent

