### PR TITLE
Swap API URI to local json-server in dev

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,9 +1,17 @@
 import axios from 'axios';
+
+let _apiURI = null;
+if (process.env.NODE_ENV === 'development') {
+  _apiURI = location.protocol + '//' + location.hostname + ':3001/';
+} else {
+  _apiURI = 'https://socent.cezarneaga.eu/api/v1/';
+}
+
 function getEnterprises() {
-  return axios.get('https://socent.cezarneaga.eu/api/v1/enterprises?status=neq|10')
+  return axios.get(_apiURI + 'enterprises?status=neq|10')
 }
 function getEnterprise(id) {
-  return axios.get(`https://socent.cezarneaga.eu/api/v1/enterprises/${id}`)
+  return axios.get(`${_apiURI}enterprises/${id}`)
 }
 function getEnterprisesPublic() {
   return axios.get('/public')


### PR DESCRIPTION
#### Fixes #N/A

#### Here are the changes I propose:
Should use json-server for development and live server for production (developer can change URI manually if they need to test with prod API)

#### Test plan:
Load page, check that URIs are built correctly for both NODE_ENV in development as well as production

#### Suggested reviewers: @gov-ithub/socent, @cezarneaga 

