### PR TITLE
fix flow errors

### DIFF
--- a/src/api/Caens.js
+++ b/src/api/Caens.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Entity, {APIEndpoints} from './Entity';
+import Entity from './Entity';
 
 import type {
   APIPayload,
@@ -10,31 +10,31 @@ export default class Caens extends Entity {
   delete(
     id: number,
   ): Promise<Object> {
-    return this._deleteID(APIEndpoints.industry_classifications, id);
+    return this._deleteID("industry-classifications", id);
   }
 
   update(
     id: number,
     payload: APIPayload,
   ): Promise<Object> {
-    return this._update(APIEndpoints.industry_classifications, id, payload);
+    return this._update("industry-classifications", id, payload);
   }
 
   create(
     payload: APIPayload,
   ): Promise<Object> {
-    return this._post(APIEndpoints.industry_classifications, payload);
+    return this._post("industry-classifications", payload);
   }
 
   list(
     params: APIPayload,
   ): Promise<Object> {
-    return this._get(APIEndpoints.industry_classifications, params);
+    return this._get("industry-classifications", params);
   }
 
   getByID(
     id: number,
   ): Promise<Object> {
-    return this._getID(APIEndpoints.industry_classifications, id);
+    return this._getID("industry-classifications", id);
   }
 }

--- a/src/api/Domains.js
+++ b/src/api/Domains.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Entity, {APIEndpoints} from './Entity';
+import Entity from './Entity';
 
 import type {
   APIPayload,
@@ -10,12 +10,12 @@ export default class Domains extends Entity {
   list(
     params: APIPayload,
   ): Promise<Object> {
-    return this._get(APIEndpoints.social_intervention_domains, params);
+    return this._get("social-intervention-domains", params);
   }
 
   getByID(
     id: number,
   ): Promise<Object> {
-    return this._getID(APIEndpoints.social_intervention_domains, id);
+    return this._getID("social-intervention-domains", id);
   }
 }

--- a/src/api/Enterprise.js
+++ b/src/api/Enterprise.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Entity, {APIEndpoints} from './Entity';
+import Entity from './Entity';
 
 import type { 
   APIPayload,
@@ -10,31 +10,31 @@ export default class Enterprise extends Entity {
   delete(
     id: number,
   ): Promise<Object> {
-    return this._deleteID(APIEndpoints.enterprises, id);
+    return this._deleteID("enterprises", id);
   }  
 
   update(
     id: number,
     payload: APIPayload,
   ): Promise<Object> {
-    return this._update(APIEndpoints.enterprises, id, payload);
+    return this._update("enterprises", id, payload);
   }
 
   create(
     payload: APIPayload,
   ): Promise<Object> {
-    return this._post(APIEndpoints.enterprises, payload);
+    return this._post("enterprises", payload);
   }
 
   list(
     params: APIPayload,
   ): Promise<Object> {
-    return this._get(APIEndpoints.enterprises, params);
+    return this._get("enterprises", params);
   }
 
   getByID(
     id: number,
   ): Promise<Object> {
-    return this._getID(APIEndpoints.enterprises, id);
+    return this._getID("enterprises", id);
   }
 }

--- a/src/api/Entity.js
+++ b/src/api/Entity.js
@@ -1,7 +1,7 @@
 // @flow
 
 import axios from 'axios';
-
+/*
 export const APIEndpoints = {
   enterprises: "enterprises",
   public: "public",
@@ -10,6 +10,14 @@ export const APIEndpoints = {
   social_intervention_domains: "social-intervention-domains"
 };
 export type APIEndpoint = $Keys<typeof APIEndpoints>;
+*/
+
+export type APIEndpoint = 
+  "enterprises" |
+  "public" |
+  "list" |
+  "industry-classifications" |
+  "social-intervention-domains";
 
 export const APIVersions = {
   v1: "v1",

--- a/src/api/Entity.test.js
+++ b/src/api/Entity.test.js
@@ -2,8 +2,6 @@
 
 import Entity from './Entity';
 
-import { APIEndpoints } from './Entity';
-
 const TestEntity = new Entity(
   'localhost',
   'v1',
@@ -34,7 +32,7 @@ describe('Entity URI manipulation', () => {
       node_env: string,
     ): string {
       process.env.NODE_ENV = node_env;
-      return TestEntity._buildEndpoint(APIEndpoints.enterprises);
+      return TestEntity._buildEndpoint("enterprises");
     }
 
     const dev_endpoint = getEndpoint("development");
@@ -58,10 +56,10 @@ describe('Entity base API calls', () => {
   it ('returns a Promise', () => {
 	  createXHRmock();
 
-    expect(TestEntity._getID(APIEndpoints.enterprises, -1)).toBeTruthy();
-    expect(TestEntity._get(APIEndpoints.enterprises, {'foo': 'bar'})).toBeTruthy();
-    expect(TestEntity._deleteID(APIEndpoints.enterprises, -1)).toBeTruthy();
-    expect(TestEntity._post(APIEndpoints.enterprises, {'foo' : 'bar'})).toBeTruthy();
-    expect(TestEntity._update(APIEndpoints.enterprises, -1, {'foo' : 'bar'})).toBeTruthy();
+    expect(TestEntity._getID("enterprises", -1)).toBeTruthy();
+    expect(TestEntity._get("enterprises", {'foo': 'bar'})).toBeTruthy();
+    expect(TestEntity._deleteID("enterprises", -1)).toBeTruthy();
+    expect(TestEntity._post("enterprises", {'foo' : 'bar'})).toBeTruthy();
+    expect(TestEntity._update("enterprises", -1, {'foo' : 'bar'})).toBeTruthy();
   });
 });


### PR DESCRIPTION
#### Fixes #49 

#### Here are the changes I propose:
Instead of trying to build an Enum type, use a disjoint union with literal types. This allows Flow to check for code correctness (ie: passing an undefined APIEndpoint will throw an error) while not creating any problems due to endpoint formatting.

#### Test plan:
`yarn flow` 

#### Suggested reviewers: @gov-ithub/socent, @cezarneaga 
