### PR TITLE
Fix API test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules
 
 # testing
 coverage
-jest
+/jest/
 
 # production
 build

--- a/src/api/API.test.js
+++ b/src/api/API.test.js
@@ -1,7 +1,5 @@
-
-
 import API from './API';
-//import Enterprise from './Enterprise';
+import '../jest/localstorage';
 
 const TestAPI = new API(
   'localhost',

--- a/src/jest/localstorage.js
+++ b/src/jest/localstorage.js
@@ -1,0 +1,19 @@
+var localStorageMock = (function() {
+  var store = {};
+
+  return {
+    getItem: function(key) {
+      return store[key] || null;
+    },
+    setItem: function(key, value) {
+      store[key] = value.toString();
+    },
+    clear: function() {
+      store = {};
+    }
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock
+});


### PR DESCRIPTION
#### Here are the changes I propose:
`API.test.js` fails because jest doesn't know about local storage - this PR adds the mock functions for it.

#### Test plan:
`npm test`

#### Suggested reviewers: @gov-ithub/socent, @cezarneaga 
