### PR TITLE
Use js-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "history": "^4.5.1",
     "intl": "^1.2.5",
     "intl-locales-supported": "^1.0.0",
+    "js-logger": "^1.3.0",
     "jwt-decode": "^2.1.0",
     "material-ui": "^0.16.6",
     "react": "^15.4.2",

--- a/src/api/API.js
+++ b/src/api/API.js
@@ -12,6 +12,10 @@ import {browserHistory} from "react-router";
 
 import type { APIVersion } from './Entity';
 
+import Logger from 'js-logger';
+
+Logger.useDefaults();
+
 type UserCredentials = {
   email: string,
   password: string,
@@ -59,7 +63,7 @@ export default class API {
   }
 
   login(user: UserCredentials): Promise<Object> {
-    console.log("loginUser:", user.email, user.password);
+    Logger.info("loginUser:", user.email, user.password);
     let ent = new Entity(this._baseURI, this._version, this._token);
 
     return new Promise((resolve, reject) => {
@@ -70,14 +74,14 @@ export default class API {
         .then(resp => {
           // {authorizationToken: {token: ..., exp: <expiry-8601>, user_name: ...}}
           var json = resp.data.authorizationToken;
-          console.log("loginUser: ", resp, json);
-          console.log("JWT: ", json.token);
+          Logger.info("loginUser: ", resp, json);
+          Logger.info("JWT: ", json.token);
           this._setToken(json.token);
           browserHistory.push("/admin");
           resolve(json);
         })
         .catch(err => {
-          console.log("loginUser: error:", err);
+          Logger.info("loginUser: error:", err);
           reject(err);
         });
       }

--- a/src/containers/AdminContainer.js
+++ b/src/containers/AdminContainer.js
@@ -2,6 +2,10 @@ import React, {PropTypes, Component} from 'react'
 import API from '../api/API.js'
 import Admin from '../components/Admin'
 
+import Logger from 'js-logger';
+
+Logger.useDefaults();
+
 export default class AdminContainer extends Component {
   constructor(props) {
     super(props);
@@ -41,7 +45,7 @@ export default class AdminContainer extends Component {
         })
       })
       .catch(function (error) {
-        console.log(error);
+        Logger.info(error);
       })
   }
 

--- a/src/containers/RegistrationContainer.js
+++ b/src/containers/RegistrationContainer.js
@@ -4,6 +4,8 @@ import Registration from '../components/Registration'
 import axios from 'axios'
 import API from '../api/API'
 
+import Logger from 'js-logger';
+
 export default class RegistrationContainer extends Component {
   constructor(props) {
     super(props);
@@ -54,10 +56,10 @@ export default class RegistrationContainer extends Component {
 
   addCaenComponent() {
     const { secondaryIndustryClassifications } = this.state.enterprise;
-    console.log(secondaryIndustryClassifications);
+    Logger.info(secondaryIndustryClassifications);
     const newCaenSecondary = secondaryIndustryClassifications.concat(null);
     const newCaenSecObject = {secondaryIndustryClassifications: newCaenSecondary}
-    console.log(newCaenSecObject);
+    Logger.info(newCaenSecObject);
     this.setState({
       enterprise: {...this.state.enterprise, ...newCaenSecObject}
     });

--- a/src/layout/SignIn/index.js
+++ b/src/layout/SignIn/index.js
@@ -1,5 +1,8 @@
 import React from "react";
 import API from "../../api/API";
+import Logger from "js-logger";
+
+Logger.useDefaults();
 
 const SignIn = () => {
   let username;
@@ -10,9 +13,9 @@ const SignIn = () => {
     api.login(
       {email: username.value, password: password.value}
     ).then(
-      jwt => console.log("App::ctor::then", jwt)
+      jwt => Logger.info("App::ctor::then", jwt)
     ).catch(
-      err => console.log("App::ctor::catch", err)
+      err => Logger.info("App::ctor::catch", err)
     );
   };
 


### PR DESCRIPTION
#### Here are the changes I propose:
We use `console.log` in development but we need a good way to send logged data back to the server in production. `js-logger` allows us to extend the default behaviour (console logging) so that we can do so. 

#### Test plan:
`npm start` and login - notice logs being sent to console as expected

#### Suggested reviewers: @gov-ithub/socent
